### PR TITLE
Improve home and find interaction

### DIFF
--- a/item_tracker/component_fetcher.py
+++ b/item_tracker/component_fetcher.py
@@ -231,9 +231,12 @@ def main():
 
     def periodic():
         try:
-            ser.readline()
+            line = ser.readline().decode('utf-8')
         except Exception:
-            pass
+            line = ''
+
+        if line == 'NEXT\n':
+            handle_next()
 
         if location_buffer:
             if not homed:


### PR DESCRIPTION
## Summary
- maintain a `homed` flag so the robot can stay at Home until Next or Find are pressed
- Next returns to the first item when homed and otherwise steps through the queue
- periodic task now sends the first item only when not homed
- popups and widget layout unchanged from prior commit

## Testing
- `python -m py_compile item_tracker/component_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_6874ead4f64c832892db0524a9852baa