### PR TITLE
Add dual-core stepper control firmware for CoreS3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,13 @@
+[platformio]
+src_dir = M5_code
+
+[env:m5stack-cores3]
+platform = espressif32
+board = m5stack-cores3
+framework = arduino
+lib_deps =
+  m5stack/M5Unified
+  EinarArnason/ESP_FlexyStepper
+  ottowinter/ESPAsyncWebServer-esphome
+  esphome/AsyncTCP-esphome
+


### PR DESCRIPTION
## Summary
- Implement dual-core firmware for M5Stack CoreS3 Lite using ESP_FlexyStepper
- Add WiFi/touch/display UI task on Core 0 and stepper motor control task on Core 1
- Provide PlatformIO configuration for building the firmware

## Testing
- `platformio run` *(fails: HTTPClientError installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_6891c569b1748328b51989ddc7c0d6ab